### PR TITLE
feat: 加入slot使得row可以引入自定义组件, 补充drag事件为emit，兼容之前的写法

### DIFF
--- a/src/lib/dragTreeTable.vue
+++ b/src/lib/dragTreeTable.vue
@@ -77,6 +77,7 @@
         default: true
       },
       data: Object,
+      onDrag: Function,
       fixed: String | Boolean,
       height: String | Number,
       border: String,
@@ -270,6 +271,7 @@
         }
         pushData(curList, newList)
         this.resetOrder(newList)
+        this.onDrag(newList, curDragItem, taggetItem, _this.whereInsert)
         this.$emit("drag",newList, curDragItem, taggetItem, _this.whereInsert);
       },
       // 重置所有数据的顺序order

--- a/src/lib/dragTreeTable.vue
+++ b/src/lib/dragTreeTable.vue
@@ -8,7 +8,7 @@
             :border="border === undefined ? resize : border"
             v-bind:class="['align-' + item.titleAlign, 'colIndex' + index]"
             :key="index" >
-            <input 
+            <input
               v-if="item.type == 'checkbox'"
               class="checkbox"
               type="checkbox"
@@ -33,6 +33,12 @@
             :border="border === undefined ? resize : border"
             :isContainChildren="isContainChildren"
             :key="index">
+              <template v-slot:selection="{row}">
+                <slot name="selection" v-bind:row="row"></slot>
+              </template>
+              <template v-for="(subItem, subIndex) in data.columns"  v-slot:[subItem.type]="{row}">
+                <slot :name="subItem.type" v-bind:row="row"></slot>
+              </template>
         </row>
         </div>
         <div class="drag-line">
@@ -71,7 +77,6 @@
         default: true
       },
       data: Object,
-      onDrag: Function,
       fixed: String | Boolean,
       height: String | Number,
       border: String,
@@ -265,7 +270,7 @@
         }
         pushData(curList, newList)
         this.resetOrder(newList)
-        this.onDrag(newList, curDragItem, taggetItem, _this.whereInsert)
+        this.$emit("drag",newList, curDragItem, taggetItem, _this.whereInsert);
       },
       // 重置所有数据的顺序order
       resetOrder(list) {

--- a/src/lib/dragTreeTable.vue
+++ b/src/lib/dragTreeTable.vue
@@ -77,7 +77,10 @@
         default: true
       },
       data: Object,
-      onDrag: Function,
+      onDrag: {
+        type:Function,
+        default: ()=>{}
+      },
       fixed: String | Boolean,
       height: String | Number,
       border: String,

--- a/src/lib/row.vue
+++ b/src/lib/row.vue
@@ -22,8 +22,9 @@
                         </span>
                         <span v-else class="zip-icon arrow-transparent">
                         </span>
-                        <slot name="selection" v-bind:row="model"></slot>
-
+                        <span v-if="subItem.formatter" v-html="subItem.formatter(model)"></span>
+                        <span v-else-if="subItem.field" v-html="model[subItem.field]"></span>
+                        <slot v-else name="selection" v-bind:row="model"></slot>
                     </span>
                     <span v-else-if="subItem.type === 'checkbox'">
                       <input type="checkbox"
@@ -32,6 +33,18 @@
                         v-model="model[custom_field.checked]"
                         class="checkbox action-item"
                         @click.stop="onCheckboxClick($event, model)"/>
+                    </span>
+                    <span v-else-if="subItem.type === 'action'">
+                        <span v-if="subItem.actions">
+                            <a class="action-item"
+                                v-for="(acItem, acIndex) in subItem.actions"
+                                :key="acIndex"
+                                type="text" size="small"
+                                @click.stop.prevent="acItem.onclick(model)">
+                                <i :class="acItem.icon" v-html="acItem.formatter(model)"></i>
+                            </a>
+                        </span>
+                        <span v-else><slot name="action" v-bind:row="model"></slot></span>
                     </span>
                     <span v-else-if="subItem.type">
                         <slot :name="subItem.type" v-bind:row="model"></slot>

--- a/src/lib/row.vue
+++ b/src/lib/row.vue
@@ -22,18 +22,8 @@
                         </span>
                         <span v-else class="zip-icon arrow-transparent">
                         </span>
-                        <span v-if="subItem.formatter" v-html="subItem.formatter(model)"></span>
-                        <span v-else v-html="model[subItem.field]"></span>
+                        <slot name="selection" v-bind:row="model"></slot>
 
-                    </span>
-                    <span v-else-if="subItem.type === 'action'">
-                        <a class="action-item"
-                            v-for="(acItem, acIndex) in subItem.actions"
-                            :key="acIndex"
-                            type="text" size="small" 
-                            @click.stop.prevent="acItem.onclick(model)">
-                            <i :class="acItem.icon" v-html="acItem.formatter(model)"></i>
-                        </a>
                     </span>
                     <span v-else-if="subItem.type === 'checkbox'">
                       <input type="checkbox"
@@ -42,6 +32,9 @@
                         v-model="model[custom_field.checked]"
                         class="checkbox action-item"
                         @click.stop="onCheckboxClick($event, model)"/>
+                    </span>
+                    <span v-else-if="subItem.type">
+                        <slot :name="subItem.type" v-bind:row="model"></slot>
                     </span>
                     <span v-else>
                         <span v-if="subItem.formatter" v-html="subItem.formatter(model)"></span>
@@ -73,6 +66,12 @@
                 :onCheck="onCheck"
                 :isContainChildren="isContainChildren"
                 v-if="isFolder">
+                    <template v-slot:selection="{row}">
+                    <slot name="selection" v-bind:row="row"></slot>
+                    </template>
+                    <template v-for="(subItem, subIndex) in columns"  v-slot:[subItem.type]="{row}">
+                    <slot :name="subItem.type" v-bind:row="row"></slot>
+                    </template>
             </row>
         </div>
         

--- a/src/view/demo.vue
+++ b/src/view/demo.vue
@@ -23,7 +23,7 @@
     <template #action="{row}">
       <a class="action-item" @click.stop.prevent="add(row)">添加子节点</a>
       <a class="action-item" @click.stop.prevent="edit(row)">修改子节点</a>
-      <a class="action-item" @click.stop.prevent="onDel"><i>删除</i></a>
+      <a class="action-item" @click.stop.prevent="onDel(row)"><i>删除</i></a>
     </template>
     </dragTreeTable>
     <Dialog :onSave="onEdit" ref="editDialog"></Dialog>
@@ -116,39 +116,44 @@ export default {
         align: "center"
       },
       {
-        title: "操作",
+        title: "操作(使用actions)",
         type: "action",
         flex: 1,
         align: "center",
-        // actions: [
-        //   {
-        //     text: "添加子节点",
-        //     onclick: (item) => {
-        //       this.$refs.addDialog.show('add', item.id);
-        //     },
-        //     formatter: item => {
-        //       return "<i>添加子节点 </i>";
-        //     }
-        //   },
-        //   {
-        //     text: "修改子节点",
-        //     onclick: (item) => {
-        //       this.$refs.editDialog.show('edit', item);
-        //     },
-        //     formatter: item => {
-        //       return "<i>修改子节点 </i>";
-        //     }
-        //   },
-          
-        //   {
-        //     text: "删除",
-        //     onclick: this.onDel,
-        //     formatter: item => {
-        //       return "<i>删除</i>";
-        //     }
-        //   }
-        // ]
-      }
+        actions: [
+          {
+            text: "添加子节点",
+            onclick: (item) => {
+              this.$refs.addDialog.show('add', item.id);
+            },
+            formatter: item => {
+              return "<i>添加子节点 </i>";
+            }
+          },
+          {
+            text: "修改子节点",
+            onclick: (item) => {
+              this.$refs.editDialog.show('edit', item);
+            },
+            formatter: item => {
+              return "<i>修改子节点 </i>";
+            }
+          },
+          {
+            text: "删除",
+            onclick: this.onDel,
+            formatter: item => {
+              return "<i>删除</i>";
+            }
+          }
+        ]
+      },
+      {
+        title: "操作(使用slot自定义)",
+        type: "action",
+        flex: 1,
+        align: "center",
+      },
     ];
     this.treeData = {
       columns: columns,

--- a/src/view/demo.vue
+++ b/src/view/demo.vue
@@ -2,16 +2,29 @@
   <div id="app">
     <div id="container">
     <button @click="zipAll">全部折叠</button>
-    <button @click="openAll">全部打开</button>
+    <button @click="openAll">全部开</button>
     <button @click="highlight(true)">高亮行</button>
     <button @click="highlight(false)">取消高亮</button>
     <dragTreeTable
       ref="table"
       :data="treeData"
-      :onDrag="onTreeDataChange"
+      @drag="onTreeDataChange"
       resize
       fixed
       :isdraggable="true">
+    <template #selection="{row}">
+      {{ row.name }}
+    </template>
+
+    <template #id="{row}">
+      {{ row.id }}
+    </template>
+
+    <template #action="{row}">
+      <a class="action-item" @click.stop.prevent="add(row)">添加子节点</a>
+      <a class="action-item" @click.stop.prevent="edit(row)">修改子节点</a>
+      <a class="action-item" @click.stop.prevent="onDel"><i>删除</i></a>
+    </template>
     </dragTreeTable>
     <Dialog :onSave="onEdit" ref="editDialog"></Dialog>
     <Dialog :onSave="onAdd" ref="addDialog"></Dialog>
@@ -62,6 +75,12 @@ export default {
     },
     highlight(flag) {
       this.$refs.table.HighlightRow(383, flag, true);
+    },
+    add(row) {
+      this.$refs.addDialog.show('add', row.id);
+    },
+    edit(row) {
+      this.$refs.editDialog.show('edit', row);
     }
   },
   mounted() {
@@ -83,13 +102,10 @@ export default {
         width: 200,
         align: "left",
         titleAlign: "left",
-        formatter: item => {
-          return "<span>" + item.name + "</span>";
-        }
       },
       {
         title: "ID",
-        field: "id",
+        type: "id",
         width: 100,
         align: "center"
       },
@@ -104,34 +120,34 @@ export default {
         type: "action",
         flex: 1,
         align: "center",
-        actions: [
-          {
-            text: "添加子节点",
-            onclick: (item) => {
-              this.$refs.addDialog.show('add', item.id);
-            },
-            formatter: item => {
-              return "<i>添加子节点 </i>";
-            }
-          },
-          {
-            text: "修改子节点",
-            onclick: (item) => {
-              this.$refs.editDialog.show('edit', item);
-            },
-            formatter: item => {
-              return "<i>修改子节点 </i>";
-            }
-          },
+        // actions: [
+        //   {
+        //     text: "添加子节点",
+        //     onclick: (item) => {
+        //       this.$refs.addDialog.show('add', item.id);
+        //     },
+        //     formatter: item => {
+        //       return "<i>添加子节点 </i>";
+        //     }
+        //   },
+        //   {
+        //     text: "修改子节点",
+        //     onclick: (item) => {
+        //       this.$refs.editDialog.show('edit', item);
+        //     },
+        //     formatter: item => {
+        //       return "<i>修改子节点 </i>";
+        //     }
+        //   },
           
-          {
-            text: "删除",
-            onclick: this.onDel,
-            formatter: item => {
-              return "<i>删除</i>";
-            }
-          }
-        ]
+        //   {
+        //     text: "删除",
+        //     onclick: this.onDel,
+        //     formatter: item => {
+        //       return "<i>删除</i>";
+        //     }
+        //   }
+        // ]
       }
     ];
     this.treeData = {


### PR DESCRIPTION
加入了自定义slot
使得定义columns 表头时，
除了固定的selection, aciton和checkbox外，
传入其他的如demo中的
`
type: "id"
`
则可以
`
<template #id="{row}"> {{ row.id }} </template>
`
像这样写自定义的组件，或者可以引入第三方如ele和iview的组件

同时补充了drag事件的传递方式为emit
`
@drag="onTreeDataChange"
`
也兼容之前的:onDrag 写法
使得在传统项目中引入该组件，事件不会报错

兼容了之前的写法
使得优先级为：
formatter的v-html,
其次是只显示字段的field
再是slot

aciton的时候，传入了actions则和原来一样用actions, 否则依然是写slot自定义显示内容